### PR TITLE
DATA-423: Make this plugin upgradeable

### DIFF
--- a/palm/plugins/dbt/dbt_plugin.py
+++ b/palm/plugins/dbt/dbt_plugin.py
@@ -13,5 +13,6 @@ def get_version():
 DbtPlugin = BasePlugin(
     name = 'dbt', 
     command_dir = Path(__file__).parent / 'commands',
-    version = get_version()
+    version = get_version(),
+    package_location='https://github.com/palmetto/palm-dbt.git'
 )


### PR DESCRIPTION
Add the package location to enable upgrading this plugin from github

I ran into a weird issue with not being able to authenticate with github in the CLI during this process. Probably a bug I need to figure out in the main palm PR

