### PR TITLE
DATA-488: update cache for python3.8

### DIFF
--- a/palm/plugins/dbt/sql_to_dbt.py
+++ b/palm/plugins/dbt/sql_to_dbt.py
@@ -2,7 +2,7 @@ import re
 import click
 from shutil import copy
 from pathlib import Path
-from functools import cache
+from functools import lru_cache
 
 
 def create_dbt_sql_file(model_name: str, model_type: str) -> None:
@@ -83,8 +83,7 @@ def sql_to_md() -> str:
 
     return "## Business Notes\n\n\t## Developer Notes"
 
-
-@cache
+@lru_cache(maxsize=1)
 def get_ref_file() -> str:
     """Read the ref file, cached to reduce amount of times we need to read the file into memory
 


### PR DESCRIPTION
## Why?
Previous implementation was only supported by python 3.9+
dbt's docker image is using python 3.8, so we need to ensure our code is compatible with 3.8+

## What changed
- Switch cache to lru_cache which is supported in python 3.8 (https://docs.python.org/3.8/library/functools.html#functools.lru_cache)

## How does it affect me?
- No more errors when trying to generate a dbt model from MurphQL if you're on python 3.8