### PR TITLE
DATA-501: Fix running dbt macros via palm

### DIFF
--- a/palm/plugins/dbt/dbt_palm_utils.py
+++ b/palm/plugins/dbt/dbt_palm_utils.py
@@ -55,7 +55,8 @@ def _long_cycle(cmd: str,
     command = f"dbt clean && dbt deps {seed_cmd}" 
 
     if macros:
-        command += f" && dbt run-operation {macros}"
+        run_operation = " && dbt run-operation "
+        command += run_operation + run_operation.join(macros)
     else:
         command += f" && dbt {cmd}"
         if select and not no_seed:


### PR DESCRIPTION
Macros is a tuple and needs to be joined, otherwise it does not work!

* Fix running dbt macros via palm
* Fix ability to chain multiple macros,
which requires chaining multiple dbt run-operation calls

DATA-501

