### PR TITLE
[BUG] Add `dbt deps` to `palm snapshot` command

### DIFF
--- a/palm/plugins/dbt/commands/cmd_snapshot.py
+++ b/palm/plugins/dbt/commands/cmd_snapshot.py
@@ -14,11 +14,11 @@ def cli(ctx,
     """ Executes the DBT snapshots."""
 
     if fast:
-      cmd = "dbt snapshot"
+        cmd = "dbt snapshot"
     else:
-      cmd = "dbt clean && dbt deps && dbt snapshot"
+        cmd = "dbt clean && dbt deps && dbt snapshot"
     if select:
-      cmd += f" --select {select}"
+        cmd += f" --select {select}"
     if not persist:
         cmd += " && dbt run-operation drop_branch_schemas" 
 

--- a/palm/plugins/dbt/commands/cmd_snapshot.py
+++ b/palm/plugins/dbt/commands/cmd_snapshot.py
@@ -1,6 +1,6 @@
 import click
 from typing import Optional
-from palm.plugins.dbt.dbt_palm_utils import shell_options, dbt_env_vars
+from palm.plugins.dbt.dbt_palm_utils import dbt_env_vars
 
 @click.command("snapshot")
 @click.option("--persist", is_flag=True, help="will not drop the test schema at the end")

--- a/palm/plugins/dbt/commands/cmd_snapshot.py
+++ b/palm/plugins/dbt/commands/cmd_snapshot.py
@@ -1,19 +1,24 @@
 import click
 from typing import Optional
-from palm.plugins.dbt.dbt_palm_utils import dbt_env_vars
+from palm.plugins.dbt.dbt_palm_utils import shell_options, dbt_env_vars
 
 @click.command("snapshot")
 @click.option("--persist", is_flag=True, help="will not drop the test schema at the end")
 @click.option("--select", multiple=True)
+@click.option("--fast", is_flag=True, help="will skip clean/deps/seed")
 @click.pass_context
 def cli(ctx, 
         persist: bool,
+        fast: bool,
         select: Optional[tuple]=()):
     """ Executes the DBT snapshots."""
-    
-    cmd = "dbt snapshot"
+
+    if fast:
+      cmd = "dbt snapshot"
+    else:
+      cmd = "dbt clean && dbt deps && dbt snapshot"
     if select:
-        cmd += f" --select {select}"
+      cmd += f" --select {select}"
     if not persist:
         cmd += " && dbt run-operation drop_branch_schemas" 
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->
## Pull request checklist

Before submitting your PR, please review the following checklist:

- [ ] Consider adding a unit test if your PR resolves an issue.
<!-- TODO: Implement palm test and palm lint for this plugin -->
<!-- - [ ] All new and existing tests pass locally (`palm test`) -->
<!-- - [ ] Lint (`palm lint`) has passed locally and any fixes were made for failures -->
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Breaking changes

- [ ] Check if this pull request introduces a breaking change

## What does this implement/fix? Explain your changes.
Using the `palm-dbt` plugin to run `dbt snapshot` fails because the snapshot command is missing `dbt deps` (when a snapshot project runs `dbt_utils` or any other imported package's macros). This fix adds the standard long cycle and short cycle versions of the command with long cycle run by default.

## Does this close any currently open issues?
…

## Any other comments?
…

## Where has this been tested?

**Operating System:** ...

**Platform:** …

**Target Platform:** …
