### PR TITLE
[BUG] Enumerate `--select/--model` options in `snapshot` and `compile`

### DIFF
--- a/palm/plugins/dbt/commands/cmd_compile.py
+++ b/palm/plugins/dbt/commands/cmd_compile.py
@@ -17,7 +17,7 @@ def cli(ctx,
     else:
       cmd = "dbt clean && dbt deps && dbt compile"
     if models:
-      cmd += f" --models {models}"
+      cmd += f" --models " + " ".join(models)
 
     env_vars = dbt_env_vars(ctx.obj.palm.branch)
     success, msg = ctx.obj.run_in_docker(cmd, env_vars)

--- a/palm/plugins/dbt/commands/cmd_snapshot.py
+++ b/palm/plugins/dbt/commands/cmd_snapshot.py
@@ -10,7 +10,7 @@ from palm.plugins.dbt.dbt_palm_utils import dbt_env_vars
 def cli(ctx, 
         persist: bool,
         fast: bool,
-        select: Optional[tuple]=()):
+        select: Optional[tuple] = tuple()):
     """ Executes the DBT snapshots."""
 
     if fast:

--- a/palm/plugins/dbt/commands/cmd_snapshot.py
+++ b/palm/plugins/dbt/commands/cmd_snapshot.py
@@ -18,7 +18,7 @@ def cli(ctx,
     else:
         cmd = "dbt clean && dbt deps && dbt snapshot"
     if select:
-        cmd += f" --select {select}"
+        cmd += f" --select " + " ".join(select)
     if not persist:
         cmd += " && dbt run-operation drop_branch_schemas" 
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ long_description = Path(this_directory, 'README.md').read_text()
 
 setup(
     name='palm-dbt',
-    version='0.0.2',
+    version='0.0.3',
     description='dbt extension for Palm CLI',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ long_description = Path(this_directory, 'README.md').read_text()
 
 setup(
     name='palm-dbt',
-    version='0.0.3',
+    version='0.0.2',
     description='dbt extension for Palm CLI',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->
## Pull request checklist

Before submitting your PR, please review the following checklist:

- [ ] Consider adding a unit test if your PR resolves an issue.
<!-- TODO: Implement palm test and palm lint for this plugin -->
<!-- - [ ] All new and existing tests pass locally (`palm test`) -->
<!-- - [ ] Lint (`palm lint`) has passed locally and any fixes were made for failures -->
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Breaking changes

- [ ] Check if this pull request introduces a breaking change

## What does this implement/fix? Explain your changes.
`palm snapshot --select model1 model2` currently fails because the snapshot command fails to enumerate the objects in the tuple of select values. We previously fixed this for `palm run` and a few other commands, but failed to catch every instance.

This fix properly enumerates the items in the tuple captured with the `--select` flag or the `--model` flag for `palm compile` and `palm snapshot`.

## Does this close any currently open issues?
…

## Any other comments?
…