### PR TITLE
DATA-478: Add shell command with dbt environment variables

### DIFF
--- a/palm/plugins/dbt/commands/cmd_shell.py
+++ b/palm/plugins/dbt/commands/cmd_shell.py
@@ -1,0 +1,10 @@
+import click
+from palm.plugins.dbt.dbt_palm_utils import dbt_env_vars
+
+
+@click.command('shell')
+@click.pass_context
+def cli(ctx):
+    """Bash into your docker image to run arbitrary commands"""
+    env_vars = dbt_env_vars(ctx.obj.palm.branch)
+    ctx.obj.run_in_docker('bash', env_vars)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->
## Pull request checklist

Before submitting your PR, please review the following checklist:

- [x] Consider adding a unit test if your PR resolves an issue.
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Breaking changes

- [ ] Check if this pull request introduces a breaking change

## What does this implement/fix? Explain your changes.

This allows users to shell into their container and run arbitrary commands
useful for power users who need direct access to their underlying CLIs
and for debugging problems inside of the container

## Does this close any currently open issues?
DATA-478

## Any other comments?
Pairs well with https://github.com/palmetto/palm-cli/pull/28/files

## Where has this been tested?

**Operating System:** MacOS