### PR TITLE
Use dbt's Native Profiles Resolution When Containerizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,14 @@ plugins:
   - dbt
 ```
 
-If you optionally accept the prompt to add the profiles.yml file, do be sure to fill it in properly as well. Your dbt project will not run without it!
+## Palm-ing an existing dbt project
+palm-dbt ships with a command to containerize and convert your existing dbt project.
+
+```
+  palm containerize
+```
+
+Follow the prompts to select a dbt version and you will be ready to use this package. 
 
 ### Adding palm dbt macros
 

--- a/palm/plugins/dbt/dbt_containerizer.py
+++ b/palm/plugins/dbt/dbt_containerizer.py
@@ -110,7 +110,7 @@ class DbtContainerizer(PythonContainerizer):
         if profile_path := os.getenv("DBT_PROFILES_DIR"):
             profiles_dir = Path(profile_path)
             if not profiles_dir.exists():
-                raise AbortPalm("your host has a non-existant DBT_PROFILES_DIR value!")
+                raise AbortPalm("Your host has a non-existant DBT_PROFILES_DIR value!")
             if project_path in profiles_dir.parents:
                 def return_relative(prefix:str) -> str:
                     return str(profiles_dir).\

--- a/palm/plugins/dbt/dbt_containerizer.py
+++ b/palm/plugins/dbt/dbt_containerizer.py
@@ -1,4 +1,4 @@
-import os, sys, yaml
+import os, sys
 from pathlib import Path
 from typing import Optional, Tuple
 from palm.containerizer import PythonContainerizer

--- a/palm/plugins/dbt/dbt_containerizer.py
+++ b/palm/plugins/dbt/dbt_containerizer.py
@@ -112,16 +112,25 @@ class DbtContainerizer(PythonContainerizer):
             if not profiles_dir.exists():
                 raise AbortPalm("Your host has a non-existant DBT_PROFILES_DIR value!")
             if project_path in profiles_dir.parents:
-                def return_relative(prefix:str) -> str:
-                    return str(profiles_dir).\
-                        replace(str(project_path),
-                                    prefix)
-                return (return_relative("."),
-                        return_relative("/app"),)
+                return cls._relative_paths(profiles_dir, project_path)
             return str(profiles_dir), container_default
         default_profile_path = Path.home() / ".dbt"
         if not default_profile_path.exists():
             click.secho("No DBT profile found. Skipping.", fg="yellow")
             return None, None
         return str(default_profile_path), container_default  
+
+    @classmethod
+    def _relative_paths(cls, 
+                        profiles_dir:str,
+                        project_path:str) -> tuple:
+        """the relative child path of the given profiles dir
+           Args:
+            profiles_dir: where is the profile? 
+            project_path: the root of the project
+           Returns:
+            relative host and container paths <host_relative_path>, <container_absolute_path>,
+        """
+        return tuple([str(profiles_dir).replace(str(project_path), prefix) \
+                      for prefix in (".","/app",)])
         

--- a/palm/plugins/dbt/dbt_containerizer.py
+++ b/palm/plugins/dbt/dbt_containerizer.py
@@ -1,5 +1,6 @@
 from pathlib import Path
-from typing import Optional
+from typing import Optional, \
+    Tuple
 from palm.containerizer import PythonContainerizer
 import sys
 from palm.palm_exceptions import AbortPalm
@@ -146,3 +147,19 @@ class DbtContainerizer(PythonContainerizer):
             True
         """
         return True
+
+    def determine_profile_strategy() -> Tuple[str,str]:
+        """determines where the on-the-host project 
+           has been storing the profiles.yml file
+           Returns:
+              the host and container volume mount values
+        """
+        return False
+        ## is profile path envar set? 
+            ## is it in the repo?
+                # create the envar path relative to the /app in container
+                # pass that as the compose envar for DBT_PROFILES_DIR
+            ## else
+                # explicitly set that path in .env via compose as /root/.dbt/profiles.yml
+        ## else
+            ## explicitly set expanded ~/.dbt/profiles.yml in env 

--- a/palm/plugins/dbt/dbt_containerizer.py
+++ b/palm/plugins/dbt/dbt_containerizer.py
@@ -158,6 +158,7 @@ class DbtContainerizer(PythonContainerizer):
            Returns:
               the host and container volume mount values
         """
+        container_default = "/root/.dbt"
         if profile_path := os.getenv("DBT_PROFILES_DIR"):
             profiles_dir = Path(profile_path)
             if not profiles_dir.exists():
@@ -169,8 +170,11 @@ class DbtContainerizer(PythonContainerizer):
                                     prefix)
                 return (return_relative("."),
                         return_relative("/app"),)
-            return str(profiles_dir), "/root/.dbt"
-        return False
+            return str(profiles_dir), container_default
+        default_profile_path = Path.home() / ".dbt"
+        if not default_profile_path.exists():
+            return None, None
+        return str(default_profile_path), container_default  
         ## is profile path envar set? 
             ## is it in the repo?
                 # create the envar path relative to the /app in container

--- a/palm/plugins/dbt/dbt_containerizer.py
+++ b/palm/plugins/dbt/dbt_containerizer.py
@@ -1,9 +1,6 @@
-import os, \
-    sys, \
-    yaml
+import os, sys, yaml
 from pathlib import Path
-from typing import Optional, \
-    Tuple
+from typing import Optional, Tuple
 from palm.containerizer import PythonContainerizer
 from palm.palm_exceptions import AbortPalm
 import click
@@ -71,21 +68,27 @@ class DbtContainerizer(PythonContainerizer):
         profile_strategy = self.determine_profile_strategy(Path.cwd())
         replacements = dict()
         if any(profile_strategy):
-            replacements = { 
-             "dbt_profile_host": profile_strategy[0],
-             "profile_volume_mount": ":".join(("${DBT_PROFILE_HOST}",
-                                                profile_strategy[1]))
-            } 
+            replacements = {
+                "dbt_profile_host": profile_strategy[0],
+                "profile_volume_mount": ":".join(
+                    ("${DBT_PROFILE_HOST}", profile_strategy[1])
+                ),
+            }
             with Path(".env").open("a") as env_file:
-                env_file.write((f"DBT_PROFILE_HOST={profile_strategy[0]}\n"
-                                f"DBT_PROFILES_DIR={profile_strategy[1]}"))
+                env_file.write(
+                    (
+                        f"DBT_PROFILE_HOST={profile_strategy[0]}\n"
+                        f"DBT_PROFILES_DIR={profile_strategy[1]}"
+                    )
+                )
 
-
-        replacements.update({
-            "project_name": self.project_name,
-            "package_manager": self.package_manager,
-            "dbt_version": self.dbt_version,
-        })
+        replacements.update(
+            {
+                "project_name": self.project_name,
+                "package_manager": self.package_manager,
+                "dbt_version": self.dbt_version,
+            }
+        )
         return replacements
 
     def validate_python_version(self) -> bool:
@@ -97,14 +100,14 @@ class DbtContainerizer(PythonContainerizer):
         return True
 
     @classmethod
-    def determine_profile_strategy(cls, project_path:"Path") -> Tuple[str,str]:
-        """determines where the on-the-host project 
-           has been storing the profiles.yml file
+    def determine_profile_strategy(cls, project_path: "Path") -> Tuple[str, str]:
+        """determines where the on-the-host project
+        has been storing the profiles.yml file
 
-           Args:
-            project_path: the project root to convert
-           Returns:
-              the host and container volume mount values
+        Args:
+         project_path: the project root to convert
+        Returns:
+           the host and container volume mount values
         """
         container_default = "/root/.dbt"
         if profile_path := os.getenv("DBT_PROFILES_DIR"):
@@ -118,19 +121,23 @@ class DbtContainerizer(PythonContainerizer):
         if not default_profile_path.exists():
             click.secho("No DBT profile found. Skipping.", fg="yellow")
             return None, None
-        return str(default_profile_path), container_default  
+        return str(default_profile_path), container_default
 
     @classmethod
-    def _relative_paths(cls, 
-                        profiles_dir:str,
-                        project_path:str) -> tuple:
+    def _relative_paths(cls, profiles_dir: str, project_path: str) -> tuple:
         """the relative child path of the given profiles dir
-           Args:
-            profiles_dir: where is the profile? 
-            project_path: the root of the project
-           Returns:
-            relative host and container paths <host_relative_path>, <container_absolute_path>,
+        Args:
+         profiles_dir: where is the profile?
+         project_path: the root of the project
+        Returns:
+         relative host and container paths <host_relative_path>, <container_absolute_path>,
         """
-        return tuple([str(profiles_dir).replace(str(project_path), prefix) \
-                      for prefix in (".","/app",)])
-        
+        return tuple(
+            [
+                str(profiles_dir).replace(str(project_path), prefix)
+                for prefix in (
+                    ".",
+                    "/app",
+                )
+            ]
+        )

--- a/palm/plugins/dbt/dbt_containerizer.py
+++ b/palm/plugins/dbt/dbt_containerizer.py
@@ -169,6 +169,7 @@ class DbtContainerizer(PythonContainerizer):
                                     prefix)
                 return (return_relative("."),
                         return_relative("/app"),)
+            return str(profiles_dir), "/root/.dbt"
         return False
         ## is profile path envar set? 
             ## is it in the repo?

--- a/palm/plugins/dbt/dbt_containerizer.py
+++ b/palm/plugins/dbt/dbt_containerizer.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 from typing import Optional, \
     Tuple
@@ -148,12 +149,26 @@ class DbtContainerizer(PythonContainerizer):
         """
         return True
 
-    def determine_profile_strategy() -> Tuple[str,str]:
+    def determine_profile_strategy(project_path:"Path") -> Tuple[str,str]:
         """determines where the on-the-host project 
            has been storing the profiles.yml file
+
+           Args:
+            project_path: the project root to convert
            Returns:
               the host and container volume mount values
         """
+        if profile_path := os.getenv("DBT_PROFILES_DIR"):
+            profiles_dir = Path(profile_path)
+            if not profiles_dir.exists():
+                raise AbortPalm("your host has a non-existant DBT_PROFILES_DIR value!")
+            if project_path in profiles_dir.parents:
+                def return_relative(prefix:str) -> str:
+                    return str(profiles_dir).\
+                        replace(str(project_path),
+                                    prefix)
+                return (return_relative("."),
+                        return_relative("/app"),)
         return False
         ## is profile path envar set? 
             ## is it in the repo?

--- a/palm/plugins/dbt/sql_to_dbt.py
+++ b/palm/plugins/dbt/sql_to_dbt.py
@@ -17,7 +17,6 @@ def create_dbt_sql_file(model_name: str, models_path: Path) -> None:
 
     output_file = models_path / model_name / f'{model_name}.sql'
 
-
     filedata = get_ref_file()
 
     filedata = re.sub('"', "", filedata, flags=re.IGNORECASE)

--- a/palm/plugins/dbt/templates/containerize/docker-compose.yaml
+++ b/palm/plugins/dbt/templates/containerize/docker-compose.yaml
@@ -7,6 +7,9 @@ services:
       dockerfile: Dockerfile
     volumes:
       - ./:/app
+    {% if profile_volume_mount %}
+      - {{ profile_volume_mount }}
+    {% endif %}
     env_file:
       - .env
     ports: 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     author_email='data-analytics-team@palmetto.com',
     url='https://github.com/palmetto/palm-dbt',
     packages=find_namespace_packages(include=['palm', 'palm.*']),
-    package_data={'': ['palm/plugins/dbt/**/*']},
+    package_data={'': ['*.md', '*.sql', '*.yaml', '*.yml', '*.txt']},
     install_requires=Path("palm/plugins/dbt/requirements.txt").read_text().splitlines(),
     license='Apache License 2.0',
     classifiers=[

--- a/tests/unit/test_dbt_containerizer.py
+++ b/tests/unit/test_dbt_containerizer.py
@@ -81,3 +81,13 @@ def test_validate_dbt_version(environment):
     c = DbtContainerizer(ctx, templates_dir, '1.0.0')
     is_valid, message = c.validate_dbt_version()
     assert not is_valid
+
+def test_profile_strategy_in_project(tmpdir, monkeypatch):
+    """When the DBT_PROFILES_DIR is inside the project, 
+       set the path in compose relative to /app
+    """
+    config_dir = (tmpdir / "config")
+    config_dir.mkdir()
+    with monkeypatch.setenv("DBT_PROFILES_DIR", config_dir):
+        assert DbtContainerizer.determine_profile_strategy(tmpdir) == \
+            "./config", "/app/config"

--- a/tests/unit/test_dbt_containerizer.py
+++ b/tests/unit/test_dbt_containerizer.py
@@ -84,7 +84,7 @@ def test_validate_dbt_version(environment):
 
 def test_profile_strategy_in_project(tmpdir, monkeypatch):
     """When the DBT_PROFILES_DIR is inside the project, 
-       set the path in compose relative to /app
+       set the path in compose and env relative to /app
     """
     config_dir = (tmpdir / "config")
     config_dir.mkdir()
@@ -92,3 +92,15 @@ def test_profile_strategy_in_project(tmpdir, monkeypatch):
         monkey.setenv("DBT_PROFILES_DIR", str(config_dir))
         assert DbtContainerizer.determine_profile_strategy(tmpdir) == \
             ("./config", "/app/config",)
+
+def test_profile_strategy_outside_project(tmpdir, monkeypatch):
+    """When the DBT_PROFILES_DIR is outside the project, 
+       set the path in compose and env absolutely
+    """
+    project_dir = (tmpdir / "awesome_dbt_project")
+    config_dir = (tmpdir / "config")
+    config_dir.mkdir()
+    with monkeypatch.context() as monkey:
+        monkey.setenv("DBT_PROFILES_DIR", str(config_dir))
+        assert DbtContainerizer.determine_profile_strategy(project_dir) == \
+            (str(config_dir), "/root/.dbt",)

--- a/tests/unit/test_dbt_containerizer.py
+++ b/tests/unit/test_dbt_containerizer.py
@@ -1,5 +1,6 @@
 import os
 import pytest
+import mock
 from pathlib import Path
 from palm.plugins.dbt.dbt_containerizer import DbtContainerizer
 from palm.environment import Environment
@@ -104,3 +105,15 @@ def test_profile_strategy_outside_project(tmpdir, monkeypatch):
         monkey.setenv("DBT_PROFILES_DIR", str(config_dir))
         assert DbtContainerizer.determine_profile_strategy(project_dir) == \
             (str(config_dir), "/root/.dbt",)
+
+def test_profile_strategy_default(tmpdir, monkeypatch):
+    """Without a DBT_PROFILES_DIR the default behavior 
+       is the user's home .dbt adirectory. 
+    """
+    home_dir = (tmpdir / "userhome")
+    dbt_dir = home_dir / ".dbt"
+    [d.mkdir() for d in (home_dir, dbt_dir,)]
+    project_dir = (tmpdir / "awesome_dbt_project")
+    with mock.patch("pathlib.Path.home", (lambda : Path(str(home_dir)))):
+        assert DbtContainerizer.determine_profile_strategy(project_dir) == \
+        (str(dbt_dir), "/root/.dbt",)

--- a/tests/unit/test_dbt_containerizer.py
+++ b/tests/unit/test_dbt_containerizer.py
@@ -83,46 +83,64 @@ def test_validate_dbt_version(environment):
     is_valid, message = c.validate_dbt_version()
     assert not is_valid
 
+
 def test_profile_strategy_in_project(tmpdir, monkeypatch):
-    """When the DBT_PROFILES_DIR is inside the project, 
-       set the path in compose and env relative to /app
+    """When the DBT_PROFILES_DIR is inside the project,
+    set the path in compose and env relative to /app
     """
-    config_dir = (tmpdir / "config")
+    config_dir = tmpdir / "config"
     config_dir.mkdir()
     with monkeypatch.context() as monkey:
         monkey.setenv("DBT_PROFILES_DIR", str(config_dir))
-        assert DbtContainerizer.determine_profile_strategy(tmpdir) == \
-            ("./config", "/app/config",)
+        assert DbtContainerizer.determine_profile_strategy(tmpdir) == (
+            "./config",
+            "/app/config",
+        )
+
 
 def test_profile_strategy_outside_project(tmpdir, monkeypatch):
-    """When the DBT_PROFILES_DIR is outside the project, 
-       set the path in compose and env absolutely
+    """When the DBT_PROFILES_DIR is outside the project,
+    set the path in compose and env absolutely
     """
-    project_dir = (tmpdir / "awesome_dbt_project")
-    config_dir = (tmpdir / "config")
+    project_dir = tmpdir / "awesome_dbt_project"
+    config_dir = tmpdir / "config"
     config_dir.mkdir()
     with monkeypatch.context() as monkey:
         monkey.setenv("DBT_PROFILES_DIR", str(config_dir))
-        assert DbtContainerizer.determine_profile_strategy(project_dir) == \
-            (str(config_dir), "/root/.dbt",)
+        assert DbtContainerizer.determine_profile_strategy(project_dir) == (
+            str(config_dir),
+            "/root/.dbt",
+        )
+
 
 def test_profile_strategy_default(tmpdir, monkeypatch):
-    """Without a DBT_PROFILES_DIR the default behavior 
-       is the user's home .dbt adirectory. 
+    """Without a DBT_PROFILES_DIR the default behavior
+    is the user's home .dbt adirectory.
     """
-    home_dir = (tmpdir / "userhome")
+    home_dir = tmpdir / "userhome"
     dbt_dir = home_dir / ".dbt"
-    [d.mkdir() for d in (home_dir, dbt_dir,)]
-    project_dir = (tmpdir / "awesome_dbt_project")
-    with mock.patch("pathlib.Path.home", (lambda : Path(str(home_dir)))):
-        assert DbtContainerizer.determine_profile_strategy(project_dir) == \
-        (str(dbt_dir), "/root/.dbt",)
+    [
+        d.mkdir()
+        for d in (
+            home_dir,
+            dbt_dir,
+        )
+    ]
+    project_dir = tmpdir / "awesome_dbt_project"
+    with mock.patch("pathlib.Path.home", (lambda: Path(str(home_dir)))):
+        assert DbtContainerizer.determine_profile_strategy(project_dir) == (
+            str(dbt_dir),
+            "/root/.dbt",
+        )
+
 
 def test_profile_strategy_none(tmpdir, monkeypatch):
     """If we can't find a profile, return nada."""
-    home_dir = (tmpdir / "userhome")
+    home_dir = tmpdir / "userhome"
     home_dir.mkdir()
-    project_dir = (tmpdir / "awesome_dbt_project")
-    with mock.patch("pathlib.Path.home", (lambda : Path(str(home_dir)))):
-        assert DbtContainerizer.determine_profile_strategy(project_dir) == \
-        (None, None,)
+    project_dir = tmpdir / "awesome_dbt_project"
+    with mock.patch("pathlib.Path.home", (lambda: Path(str(home_dir)))):
+        assert DbtContainerizer.determine_profile_strategy(project_dir) == (
+            None,
+            None,
+        )

--- a/tests/unit/test_dbt_containerizer.py
+++ b/tests/unit/test_dbt_containerizer.py
@@ -88,6 +88,7 @@ def test_profile_strategy_in_project(tmpdir, monkeypatch):
     """
     config_dir = (tmpdir / "config")
     config_dir.mkdir()
-    with monkeypatch.setenv("DBT_PROFILES_DIR", config_dir):
+    with monkeypatch.context() as monkey:
+        monkey.setenv("DBT_PROFILES_DIR", str(config_dir))
         assert DbtContainerizer.determine_profile_strategy(tmpdir) == \
-            "./config", "/app/config"
+            ("./config", "/app/config",)

--- a/tests/unit/test_dbt_containerizer.py
+++ b/tests/unit/test_dbt_containerizer.py
@@ -117,3 +117,12 @@ def test_profile_strategy_default(tmpdir, monkeypatch):
     with mock.patch("pathlib.Path.home", (lambda : Path(str(home_dir)))):
         assert DbtContainerizer.determine_profile_strategy(project_dir) == \
         (str(dbt_dir), "/root/.dbt",)
+
+def test_profile_strategy_none(tmpdir, monkeypatch):
+    """If we can't find a profile, return nada."""
+    home_dir = (tmpdir / "userhome")
+    home_dir.mkdir()
+    project_dir = (tmpdir / "awesome_dbt_project")
+    with mock.patch("pathlib.Path.home", (lambda : Path(str(home_dir)))):
+        assert DbtContainerizer.determine_profile_strategy(project_dir) == \
+        (None, None,)


### PR DESCRIPTION
Before submitting your PR, please review the following checklist:

- [X] Consider adding a unit test if your PR resolves an issue.
   [X] All new and existing tests pass locally (`palm test`) 
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Breaking changes

- [ ] Check if this pull request introduces a breaking change

## What does this implement/fix? Explain your changes.
When containerizing an existing repository, palm will now follow dbt's pattern for finding the profiles.yml file. 
1. look for `DBT_PROFILES_DIR` envar. if it exists, use that to define the path to the file and mount it correctly.
2. define the path in `.env` so it can be unique for each user (absolute home paths are not the same ;) ) 
3. default to the dbt default, `~/.dbt`
4. if no profiles.yml exists, skip it completely

## Where has this been tested?

**Operating System:** MacOS

**Platform:** Monterey

**Target Platform:** All 
