### PR TITLE
Fix type hints for older versions of python (<3.9)

### DIFF
--- a/palm/plugins/dbt/commands/cmd_compile.py
+++ b/palm/plugins/dbt/commands/cmd_compile.py
@@ -1,5 +1,5 @@
 import click
-from typing import Optional
+from typing import Optional, Tuple
 from palm.plugins.dbt.dbt_palm_utils import dbt_env_vars
 
 
@@ -7,7 +7,7 @@ from palm.plugins.dbt.dbt_palm_utils import dbt_env_vars
 @click.option("--models", multiple=True, help="see dbt docs on models flag")
 @click.option("--fast", is_flag=True, help="will skip clean/deps/seed")
 @click.pass_context
-def cli(ctx, fast: bool, models: Optional[tuple] = tuple()):
+def cli(ctx, fast: bool, models: Optional[Tuple] = tuple()):
     """Cleans up target directory and dependencies, then compiles dbt"""
 
     if fast:

--- a/palm/plugins/dbt/commands/cmd_cycle.py
+++ b/palm/plugins/dbt/commands/cmd_cycle.py
@@ -1,5 +1,5 @@
 import click
-from typing import Optional
+from typing import Optional, Tuple
 from palm.plugins.dbt.dbt_palm_utils import dbt_env_vars
 
 # TODO: Refactor this command to reduce branching logic and simply join a list of
@@ -22,8 +22,8 @@ def cli(
     fast: bool,
     persist: bool,
     no_seed: bool,
-    models: Optional[tuple] = tuple(),
-    select: Optional[tuple] = tuple(),
+    models: Optional[Tuple] = tuple(),
+    select: Optional[Tuple] = tuple(),
 ):
     """Consecutive run-test of the DBT repo. `count` is the number of run/test cycles to execute, defaults to 2"""
 

--- a/palm/plugins/dbt/commands/cmd_run.py
+++ b/palm/plugins/dbt/commands/cmd_run.py
@@ -1,5 +1,5 @@
 import click
-from typing import Optional
+from typing import Optional, Tuple
 from palm.plugins.dbt.dbt_palm_utils import shell_options, dbt_env_vars
 
 
@@ -32,9 +32,9 @@ def cli(
     persist: bool,
     full_refresh: bool,
     no_seed: bool,
-    models: Optional[tuple] = tuple(),
-    select: Optional[tuple] = tuple(),
-    macros: Optional[tuple] = tuple(),
+    models: Optional[Tuple] = tuple(),
+    select: Optional[Tuple] = tuple(),
+    macros: Optional[Tuple] = tuple(),
 ):
     """Runs the DBT repo."""
 

--- a/palm/plugins/dbt/commands/cmd_snapshot.py
+++ b/palm/plugins/dbt/commands/cmd_snapshot.py
@@ -1,5 +1,5 @@
 import click
-from typing import Optional
+from typing import Optional, Tuple
 from palm.plugins.dbt.dbt_palm_utils import dbt_env_vars
 
 
@@ -10,7 +10,7 @@ from palm.plugins.dbt.dbt_palm_utils import dbt_env_vars
 @click.option("--select", multiple=True)
 @click.option("--fast", is_flag=True, help="will skip clean/deps/seed")
 @click.pass_context
-def cli(ctx, persist: bool, fast: bool, select: Optional[tuple] = tuple()):
+def cli(ctx, persist: bool, fast: bool, select: Optional[Tuple] = tuple()):
     """Executes the DBT snapshots."""
 
     if fast:

--- a/palm/plugins/dbt/commands/cmd_test.py
+++ b/palm/plugins/dbt/commands/cmd_test.py
@@ -1,5 +1,5 @@
 import click
-from typing import Optional
+from typing import Optional, Tuple
 from palm.plugins.dbt.dbt_palm_utils import shell_options, dbt_env_vars
 
 
@@ -19,8 +19,8 @@ def cli(
     persist: bool,
     no_seed: bool,
     no_fail_fast: bool,
-    models: Optional[tuple] = tuple(),
-    select: Optional[tuple] = tuple(),
+    models: Optional[Tuple] = tuple(),
+    select: Optional[Tuple] = tuple(),
 ):
     """Tests the DBT repo"""
 

--- a/palm/plugins/dbt/dbt_containerizer.py
+++ b/palm/plugins/dbt/dbt_containerizer.py
@@ -1,6 +1,6 @@
 import os, sys
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Dict
 from palm.containerizer import PythonContainerizer
 from palm.palm_exceptions import AbortPalm
 import click
@@ -40,7 +40,7 @@ class DbtContainerizer(PythonContainerizer):
             self.write_profile_envs()
         super().generate(self.target_dir, self.replacements)
 
-    def validate_dbt_version(self) -> tuple[bool, str]:
+    def validate_dbt_version(self) -> Tuple[bool, str]:
         """Prompts the user for a DBT version.
 
         Returns:
@@ -67,7 +67,7 @@ class DbtContainerizer(PythonContainerizer):
         return (True, f'{self.dbt_version} is valid')
 
     @property
-    def replacements(self) -> dict:
+    def replacements(self) -> Dict:
         """
         Return a dictionary of replacements for the dbt template.
         """
@@ -137,7 +137,7 @@ class DbtContainerizer(PythonContainerizer):
         return str(default_profile_path), container_default
 
     @classmethod
-    def _relative_paths(cls, profiles_dir: str, project_path: str) -> tuple:
+    def _relative_paths(cls, profiles_dir: str, project_path: str) -> Tuple[str, str]:
         """the relative child path of the given profiles dir
         Args:
          profiles_dir: where is the profile?

--- a/palm/plugins/dbt/dbt_palm_utils.py
+++ b/palm/plugins/dbt/dbt_palm_utils.py
@@ -1,5 +1,5 @@
 import re
-from typing import Optional
+from typing import Optional, Dict, Tuple
 from palm.plugins.dbt.local_user_lookup import local_user_lookup
 
 """ Shared DBT utilities to build out common CLI options """
@@ -24,8 +24,8 @@ def _short_cycle(
     no_fail_fast: Optional[bool] = False,
     full_refresh: Optional[bool] = False,
     no_seed: Optional[bool] = False,
-    models: Optional[tuple] = (),
-    macros: Optional[tuple] = (),
+    models: Optional[Tuple] = (),
+    macros: Optional[Tuple] = (),
 ) -> str:
 
     command = "" if no_seed else f" dbt seed --full-refresh && "
@@ -53,9 +53,9 @@ def _long_cycle(
     no_fail_fast: Optional[bool] = False,
     full_refresh: Optional[bool] = False,
     no_seed: Optional[bool] = False,
-    select: Optional[tuple] = (),
-    models: Optional[tuple] = (),
-    macros: Optional[tuple] = (),
+    select: Optional[Tuple] = (),
+    models: Optional[Tuple] = (),
+    macros: Optional[Tuple] = (),
 ) -> str:
     seed_cmd = "" if no_seed else "&& dbt seed --full-refresh"
     command = f"dbt clean && dbt deps {seed_cmd}"
@@ -80,7 +80,7 @@ def _long_cycle(
     return command
 
 
-def dbt_env_vars(branch: str) -> dict:
+def dbt_env_vars(branch: str) -> Dict:
     return {
         'PDP_DEV_SCHEMA': _generate_schema_from_branch(branch),
         'PDP_ENV': 'DEVELOPMENT',  # Deprecated - this will be removed!

--- a/palm/plugins/dbt/sql_to_dbt.py
+++ b/palm/plugins/dbt/sql_to_dbt.py
@@ -1,5 +1,6 @@
 import re
 import click
+from typing import Tuple
 from shutil import copy
 from pathlib import Path
 from functools import lru_cache
@@ -151,7 +152,7 @@ def get_replacements() -> list:
     return replacements
 
 
-def get_replacements_for_file(file: Path) -> tuple:
+def get_replacements_for_file(file: Path) -> Tuple:
     """Extracts the dbt naming conventions from a given file
 
     Args:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->
## Pull request checklist

Before submitting your PR, please review the following checklist:

- [x] Consider adding a unit test if your PR resolves an issue.
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Breaking changes

- [ ] Check if this pull request introduces a breaking change

## What does this implement/fix? Explain your changes.

Older versions of Python will raise an error when typehints do not use the imported Type class from typing.

## Does this close any currently open issues?
#30

## Where has this been tested?

**Operating System:**Mac OS

