### PR TITLE
[HOTFIX] Adjust python version support to match palm-cli

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -15,7 +15,7 @@ jobs:
           - 3.7
           - 3.8
           - 3.9
-          - 3.10
+          - 3.10.2
     steps:
       - uses: actions/checkout@v2
       - name: Install Python 3

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -12,10 +12,10 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - 3.6
           - 3.7
           - 3.8
           - 3.9
+          - 3.10
     steps:
       - uses: actions/checkout@v2
       - name: Install Python 3

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -36,4 +36,4 @@ jobs:
       - uses: psf/black@stable
         with:
           options: '--check --diff --skip-string-normalization --exclude="\.tpl\.py"'
-          version: '21.12b0'
+          version: '22.3.0'

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,3 @@
 -r palm/plugins/dbt/requirements.txt
 pytest >= 6.2, < 6.3
-black == 21.12b0
+black == 22.3.0

--- a/tests/unit/test_dbt_containerizer.py
+++ b/tests/unit/test_dbt_containerizer.py
@@ -4,6 +4,7 @@ import yaml
 from unittest import mock
 from pathlib import Path
 import pygit2
+import shutil
 from palm.plugins.dbt.dbt_containerizer import DbtContainerizer
 from palm.environment import Environment
 from palm.plugin_manager import PluginManager

--- a/tests/unit/test_dbt_containerizer.py
+++ b/tests/unit/test_dbt_containerizer.py
@@ -3,6 +3,7 @@ import pytest
 import yaml
 from unittest import mock
 from pathlib import Path
+import pygit2
 from palm.plugins.dbt.dbt_containerizer import DbtContainerizer
 from palm.environment import Environment
 from palm.plugin_manager import PluginManager
@@ -12,6 +13,7 @@ from palm.palm_config import PalmConfig
 class MockContext:
     def __init__(self, **kwargs):
         self.__dict__.update(kwargs)
+
 
 def mock_repository(tmp_path):
     class TemporaryRepository:
@@ -34,6 +36,7 @@ def mock_repository(tmp_path):
 
     with TemporaryRepository('testrepo.git', tmp_path) as path:
         yield pygit2.Repository(path)
+
 
 @pytest.fixture
 def environment(tmp_path, monkeypatch):


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->
## Pull request checklist

Before submitting your PR, please review the following checklist:

- [x] Consider adding a unit test if your PR resolves an issue.
<!-- TODO: Implement palm test and palm lint for this plugin -->
<!-- - [ ] All new and existing tests pass locally (`palm test`) -->
<!-- - [ ] Lint (`palm lint`) has passed locally and any fixes were made for failures -->
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Breaking changes

- [ ] Check if this pull request introduces a breaking change

## What does this implement/fix? Explain your changes.

Bump python versions in testing matrix. palm-cli no longer supports python 3.6
