### PR TITLE
[HOTFIX] model doc command

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -15,7 +15,7 @@ jobs:
           - 3.7
           - 3.8
           - 3.9
-          - 3.10.4
+          - 3.10.6
     steps:
       - uses: actions/checkout@v2
       - name: Install Python 3

--- a/palm/plugins/dbt/commands/cmd_model-doc.py
+++ b/palm/plugins/dbt/commands/cmd_model-doc.py
@@ -55,9 +55,12 @@ def get_md_destination_directory(model_path: Path, model_name: str) -> Path:
     Note that the model must have a parent directory that matches the name of
     and existing group of model docs.
     """
-    model_docs_path = Path("models/documentation/models")
+    # TODO: Implement dbt_project.yml parsing to get the docs directory (and other things)
+    # This should be read from dbt_project configuration
+    model_docs_path = Path("documentation/models")
     model_doc_types = [dir.stem for dir in model_docs_path.glob("*")]
     model_type = ''
+
     for part in model_path.parts:
         if part in model_doc_types:
             model_type = part


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->
## Pull request checklist

Before submitting your PR, please review the following checklist:

- [x] Consider adding a unit test if your PR resolves an issue.
<!-- TODO: Implement palm test and palm lint for this plugin -->
<!-- - [ ] All new and existing tests pass locally (`palm test`) -->
<!-- - [ ] Lint (`palm lint`) has passed locally and any fixes were made for failures -->
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Breaking changes

- [x] Check if this pull request introduces a breaking change

This will break model-doc for projects other than arbor.
A proper fix would involve parsing dbt_project.yaml to get the docs path.

## What does this implement/fix? Explain your changes.

Following the re-structure of pdp-arbor, the model-docs command no longer works as we moved docs to a different location.

## Does this close any currently open issues?
N/A

## Any other comments?

I'm willing to implement a proper fix here, but do not have time right now.
If we want to hold on merging this until I find time, I'm ok with it - Palmetto users should install from my branch in the interim.
