### PR TITLE
[BUGFIX] Model doc populates existing column docs

### DIFF
--- a/palm/plugins/dbt/commands/cmd_model-doc.py
+++ b/palm/plugins/dbt/commands/cmd_model-doc.py
@@ -234,9 +234,15 @@ def existing_column_docs() -> List[str]:
     Returns:
         List[str]: List of existing column doc names
     """
-    column_docs = Path("models/documentation/columns").glob("*.md")
-    column_doc_names = [column_doc.stem for column_doc in column_docs]
-    return column_doc_names
+    project_conf = parse_project()
+    if project_conf.docs_paths:
+        column_docs = []
+        for doc_path in project_conf.docs_paths:
+            column_docs.extend(Path(doc_path, 'columns').glob('*.md'))
+    else:
+        column_docs = Path("models/documentation/columns").glob("*.md")
+
+    return [column_doc.stem for column_doc in column_docs]
 
 
 def create_column_list(column_names: List[str]) -> List[dict]:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->
## Pull request checklist

Before submitting your PR, please review the following checklist:

- [x] Consider adding a unit test if your PR resolves an issue.
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Breaking changes

- [ ] Check if this pull request introduces a breaking change

## What does this implement/fix? Explain your changes.

Update model-doc command to populate existing columns when a docs_path config is present

We recently fixed this issue for generating the model.md into the correct location but missed updating the function to find existing column-level docs

This change allows model-doc to work as designed, pre-populating existing column descriptions with the doc macro where possible

