### PR TITLE
[FEATURE] Add palm dbt passthrough command

### DIFF
--- a/palm/plugins/dbt/commands/cmd_dbt.py
+++ b/palm/plugins/dbt/commands/cmd_dbt.py
@@ -64,5 +64,5 @@ def cli(
         cmd.append(" && dbt run-operation drop_branch_schemas")
 
     env_vars = dbt_env_vars(ctx.obj.palm.branch)
-    success, msg = ctx.obj.run_in_docker(cmd, env_vars)
+    success, msg = ctx.obj.run_in_docker(" ".join(cmd), env_vars)
     click.secho(msg, fg="green" if success else "red")

--- a/palm/plugins/dbt/commands/cmd_dbt.py
+++ b/palm/plugins/dbt/commands/cmd_dbt.py
@@ -73,9 +73,9 @@ def cli(
     if seed:
         cmd.insert(0, f"dbt seed --full-refresh &&")
     if select:
-        cmd.append(f" --select {select}")
+        cmd.append(f" --select {' '.join(select)}")
     if exclude:
-        cmd.append(f" --exclude {exclude}")
+        cmd.append(f" --exclude {' '.join(exclude)}")
     if selector:
         cmd.append(f" --selector {selector}")
     if fail_fast:

--- a/palm/plugins/dbt/commands/cmd_dbt.py
+++ b/palm/plugins/dbt/commands/cmd_dbt.py
@@ -6,8 +6,8 @@ from palm.plugins.dbt.dbt_palm_utils import dbt_env_vars
 
 
 @click.command("dbt")
-@click.option("--select", '-s', help="Specify the nodes to include.")
-@click.option("--exclude", '-e', help="Specify the nodes to exclude.")
+@click.option("--select", '-s', multiple=True, help="Specify the nodes to include.")
+@click.option("--exclude", '-e', multiple=True, help="Specify the nodes to exclude.")
 @click.option(
     "--selector", help="Specify the selector to use, defined in selectors.yml."
 )

--- a/palm/plugins/dbt/commands/cmd_dbt.py
+++ b/palm/plugins/dbt/commands/cmd_dbt.py
@@ -12,7 +12,7 @@ from palm.plugins.dbt.dbt_palm_utils import dbt_env_vars
 @click.option('--fail-fast', '-x', is_flag=True, default=False, help='Stop execution upon a first failure')
 @click.option("--full-refresh", is_flag=True, default=False , help="Specify the nodes to exclude.")
 @click.option("--cleanup", is_flag=True, default=False, help="Drop the schema after running the command.")
-@click.option('--no-seed', is_flag=True, default=False, help='Do not create seeds before running the command.')
+@click.option('--seed', is_flag=True, default=False, help='Create seeds before running the command.')
 @click.option("--options", '-o', help="passthrough for a string of dbt options - useful if an option you need is not available in palm")
 @click.argument("args", nargs=-1)
 @click.pass_context
@@ -23,7 +23,7 @@ def cli(
     selector: Optional[str],
     fail_fast: bool,
     full_refresh: bool,
-    no_seed: bool,
+    seed: bool,
     cleanup: bool,
     options,
     args: Tuple,
@@ -46,7 +46,7 @@ def cli(
 
     cmd = [f'dbt {" ".join(args)}']
 
-    if not no_seed:
+    if seed:
         cmd.insert(0, f"dbt seed --full-refresh &&")
     if select:
         cmd.append(f" --select {select}")

--- a/palm/plugins/dbt/commands/cmd_dbt.py
+++ b/palm/plugins/dbt/commands/cmd_dbt.py
@@ -4,16 +4,40 @@ import click
 from typing import Optional, Tuple
 from palm.plugins.dbt.dbt_palm_utils import dbt_env_vars
 
-@click.command("dbt")
 
+@click.command("dbt")
 @click.option("--select", '-s', help="Specify the nodes to include.")
 @click.option("--exclude", '-e', help="Specify the nodes to exclude.")
-@click.option("--selector", help="Specify the selector to use, defined in selectors.yml.")
-@click.option('--fail-fast', '-x', is_flag=True, default=False, help='Stop execution upon a first failure')
-@click.option("--full-refresh", is_flag=True, default=False , help="Specify the nodes to exclude.")
-@click.option("--cleanup", is_flag=True, default=False, help="Drop the schema after running the command.")
-@click.option('--seed', is_flag=True, default=False, help='Create seeds before running the command.')
-@click.option("--options", '-o', help="passthrough for a string of dbt options - useful if an option you need is not available in palm")
+@click.option(
+    "--selector", help="Specify the selector to use, defined in selectors.yml."
+)
+@click.option(
+    '--fail-fast',
+    '-x',
+    is_flag=True,
+    default=False,
+    help='Stop execution upon a first failure',
+)
+@click.option(
+    "--full-refresh", is_flag=True, default=False, help="Specify the nodes to exclude."
+)
+@click.option(
+    "--cleanup",
+    is_flag=True,
+    default=False,
+    help="Drop the schema after running the command.",
+)
+@click.option(
+    '--seed',
+    is_flag=True,
+    default=False,
+    help='Create seeds before running the command.',
+)
+@click.option(
+    "--options",
+    '-o',
+    help="passthrough for a string of dbt options - useful if an option you need is not available in palm",
+)
 @click.argument("args", nargs=-1)
 @click.pass_context
 def cli(

--- a/palm/plugins/dbt/commands/cmd_dbt.py
+++ b/palm/plugins/dbt/commands/cmd_dbt.py
@@ -1,0 +1,68 @@
+from email.policy import default
+from unittest.result import failfast
+import click
+from typing import Optional, Tuple
+from palm.plugins.dbt.dbt_palm_utils import dbt_env_vars
+
+@click.command("dbt")
+
+@click.option("--select", '-s', help="Specify the nodes to include.")
+@click.option("--exclude", '-e', help="Specify the nodes to exclude.")
+@click.option("--selector", help="Specify the selector to use, defined in selectors.yml.")
+@click.option('--fail-fast', '-x', is_flag=True, default=False, help='Stop execution upon a first failure')
+@click.option("--full-refresh", is_flag=True, default=False , help="Specify the nodes to exclude.")
+@click.option("--cleanup", is_flag=True, default=False, help="Drop the schema after running the command.")
+@click.option('--no-seed', is_flag=True, default=False, help='Do not create seeds before running the command.')
+@click.option("--options", '-o', help="passthrough for a string of dbt options - useful if an option you need is not available in palm")
+@click.argument("args", nargs=-1)
+@click.pass_context
+def cli(
+    ctx,
+    select: Optional[str],
+    exclude: Optional[str],
+    selector: Optional[str],
+    fail_fast: bool,
+    full_refresh: bool,
+    no_seed: bool,
+    cleanup: bool,
+    options,
+    args: Tuple,
+):
+    """Pass through dbt commands to the container.
+
+    This command allows you to run any dbt command in the Docker container.
+
+    The most frequently used dbt options are available as options to this command.
+    For any other options, you can use the --options flag to pass through any
+    string of options to dbt.
+
+    Example:
+    palm dbt run --select my_model --full-refresh
+    palm dbt run --options "--select my_model --full-refresh"
+    """
+    if len(args) == 0:
+        click.secho("You must provide a dbt command", fg="red")
+        return
+
+    cmd = [f'dbt {" ".join(args)}']
+
+    if not no_seed:
+        cmd.insert(0, f"dbt seed --full-refresh &&")
+    if select:
+        cmd.append(f" --select {select}")
+    if exclude:
+        cmd.append(f" --exclude {exclude}")
+    if selector:
+        cmd.append(f" --selector {selector}")
+    if fail_fast:
+        cmd.append(" --fail-fast")
+    if full_refresh:
+        cmd.append(f" --full-refresh")
+    if options:
+        cmd.append(f" {options}")
+    if cleanup:
+        cmd.append(" && dbt run-operation drop_branch_schemas")
+
+    env_vars = dbt_env_vars(ctx.obj.palm.branch)
+    success, msg = ctx.obj.run_in_docker(cmd, env_vars)
+    click.secho(msg, fg="green" if success else "red")

--- a/palm/plugins/dbt/commands/cmd_model-doc.py
+++ b/palm/plugins/dbt/commands/cmd_model-doc.py
@@ -255,15 +255,22 @@ def create_column_list(column_names: List[str]) -> List[dict]:
         List[dict]: List of column dictionaries
     """
     columns = []
-    columns_without_existing_docs = [c for c in column_names if not column_has_existing_doc(c)]
+    columns_without_existing_docs = [
+        c for c in column_names if not column_has_existing_doc(c)
+    ]
 
-    manual_descriptions = click.confirm(f'Do you want to manually enter descriptions for {len(columns_without_existing_docs)} columns?', default=False)
+    manual_descriptions = click.confirm(
+        f'Do you want to manually enter descriptions for {len(columns_without_existing_docs)} columns?',
+        default=False,
+    )
     for col_name in column_names:
         description = 'TODO: Add description'
         if column_has_existing_doc(col_name):
             description = f'{{{{ doc("{col_name}") }}}}'
         elif manual_descriptions:
-            description = click.prompt(f'Description for {col_name}', default=description)
+            description = click.prompt(
+                f'Description for {col_name}', default=description
+            )
             # TODO: Add ability to generate column doc file for manual descriptions
 
         col_dict = {"name": col_name, "description": description}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->
## Pull request checklist

Before submitting your PR, please review the following checklist:

- [x] Consider adding a unit test if your PR resolves an issue.
<!-- TODO: Implement palm test and palm lint for this plugin -->
<!-- - [ ] All new and existing tests pass locally (`palm test`) -->
<!-- - [ ] Lint (`palm lint`) has passed locally and any fixes were made for failures -->
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Breaking changes

- [ ] Check if this pull request introduces a breaking change

## What does this implement/fix? Explain your changes.

Many users are relying heavily on palm shell to allow control over the dbt commands they are running.
Adding a passthrough command allows users to run whatever commands they want inside the container.

## Any other comments?

palm dbt captures arguments as the command and allows the most common options, with the ability to specify an option string for any additional options that are needed

## Where has this been tested?

**Operating System:** macOs

**Platform:** dbt 1.2.x

**Target Platform:** dbt > 1.x (though it will work on lower versions)
