### PR TITLE
[FEATURE] Simplify run & test commands

### DIFF
--- a/palm/plugins/dbt/commands/cmd_run.py
+++ b/palm/plugins/dbt/commands/cmd_run.py
@@ -10,7 +10,7 @@ from palm.plugins.dbt.dbt_palm_utils import dbt_env_vars
     help="Disables the setting which exits immediately if a single model fails to build",
 )
 @click.option(
-    "--persist", is_flag=True, help="will not drop the test schema at the end"
+    "--clean", is_flag=True, help="Drop the test schema after the run is complete"
 )
 @click.option("--models", multiple=True, help="see dbt docs on models flag")
 @click.option("--select", multiple=True, help="see dbt docs on select flag")
@@ -25,7 +25,7 @@ from palm.plugins.dbt.dbt_palm_utils import dbt_env_vars
 def cli(
     ctx,
     no_fail_fast: bool,
-    persist: bool,
+    clean: bool,
     full_refresh: bool,
     no_seed: bool,
     models: Optional[Tuple] = tuple(),
@@ -52,7 +52,7 @@ def cli(
         cmd.append("--fail-fast")
     if full_refresh:
         cmd.append("--full-refresh")
-    if not persist:
+    if clean:
         cmd.append("&& dbt run-operation drop_branch_schemas")
 
     env_vars = dbt_env_vars(ctx.obj.palm.branch)

--- a/palm/plugins/dbt/commands/cmd_run.py
+++ b/palm/plugins/dbt/commands/cmd_run.py
@@ -54,7 +54,7 @@ def cli(
         cmd.append("--full-refresh")
     if not persist:
         cmd.append("&& dbt run-operation drop_branch_schemas")
-    
+
     env_vars = dbt_env_vars(ctx.obj.palm.branch)
     success, msg = ctx.obj.run_in_docker(" ".join(cmd), env_vars)
     click.secho(msg, fg="green" if success else "red")

--- a/palm/plugins/dbt/commands/cmd_test.py
+++ b/palm/plugins/dbt/commands/cmd_test.py
@@ -1,6 +1,6 @@
 import click
 from typing import Optional, Tuple
-from palm.plugins.dbt.dbt_palm_utils import shell_options, dbt_env_vars
+from palm.plugins.dbt.dbt_palm_utils import dbt_env_vars
 
 
 @click.command('test')
@@ -9,6 +9,7 @@ from palm.plugins.dbt.dbt_palm_utils import shell_options, dbt_env_vars
 )
 @click.option("--models", multiple=True, help="see dbt docs on models flag")
 @click.option("--select", multiple=True, help="see dbt docs on select flag")
+@click.option("--exclude", multiple=True, help="see dbt docs on exclude flag")
 @click.option("--no-fail-fast", is_flag=True, help="will run all tests if one fails")
 @click.pass_context
 def cli(
@@ -17,10 +18,25 @@ def cli(
     no_fail_fast: bool,
     models: Optional[Tuple] = tuple(),
     select: Optional[Tuple] = tuple(),
+    exclude: Optional[Tuple] = tuple(),
 ):
     """Tests the DBT repo"""
-    no_seed = True
-    cmd = shell_options("test", **locals())
+
+    cmd = ['dbt', 'test']
+    if select:
+        cmd.append('--select')
+        cmd.extend(select)
+    if models:
+        cmd.append('--models')
+        cmd.extend(models)
+    if exclude:
+        cmd.append('--exclude')
+        cmd.extend(exclude)
+    if not no_fail_fast:
+        cmd.append('--fail-fast')
+    if not persist:
+        cmd.append('&& dbt run-operation drop_branch_schemas')
+
     env_vars = dbt_env_vars(ctx.obj.palm.branch)
-    success, msg = ctx.obj.run_in_docker(cmd, env_vars)
+    success, msg = ctx.obj.run_in_docker(" ".join(cmd), env_vars)
     click.secho(msg, fg="green" if success else "red")

--- a/palm/plugins/dbt/commands/cmd_test.py
+++ b/palm/plugins/dbt/commands/cmd_test.py
@@ -5,7 +5,7 @@ from palm.plugins.dbt.dbt_palm_utils import dbt_env_vars
 
 @click.command('test')
 @click.option(
-    "--persist", is_flag=True, help="will not drop the test schema at the end"
+    "--clean", is_flag=True, help="drop the test schema after the run is complete"
 )
 @click.option("--models", multiple=True, help="see dbt docs on models flag")
 @click.option("--select", multiple=True, help="see dbt docs on select flag")
@@ -14,7 +14,7 @@ from palm.plugins.dbt.dbt_palm_utils import dbt_env_vars
 @click.pass_context
 def cli(
     ctx,
-    persist: bool,
+    clean: bool,
     no_fail_fast: bool,
     models: Optional[Tuple] = tuple(),
     select: Optional[Tuple] = tuple(),
@@ -34,7 +34,7 @@ def cli(
         cmd.extend(exclude)
     if not no_fail_fast:
         cmd.append('--fail-fast')
-    if not persist:
+    if clean:
         cmd.append('&& dbt run-operation drop_branch_schemas')
 
     env_vars = dbt_env_vars(ctx.obj.palm.branch)

--- a/palm/plugins/dbt/dbt_palm_utils.py
+++ b/palm/plugins/dbt/dbt_palm_utils.py
@@ -4,6 +4,7 @@ from palm.plugins.dbt.local_user_lookup import local_user_lookup
 
 """ Shared DBT utilities to build out common CLI options """
 
+
 def dbt_env_vars(branch: str) -> Dict:
     return {
         'PDP_DEV_SCHEMA': _generate_schema_from_branch(branch),

--- a/palm/plugins/dbt/dbt_palm_utils.py
+++ b/palm/plugins/dbt/dbt_palm_utils.py
@@ -1,50 +1,8 @@
 import re
-from typing import Optional, Dict, Tuple
+from typing import Dict
 from palm.plugins.dbt.local_user_lookup import local_user_lookup
 
 """ Shared DBT utilities to build out common CLI options """
-
-
-def shell_options(command_name: str, **kwargs):
-    # pop off unused kwargs caused by use of importlib in palm
-    kwargs.pop("ctx")
-
-    return _cycle(command_name, **kwargs)
-
-
-def _cycle(
-    cmd: str,
-    persist: Optional[bool] = False,
-    no_fail_fast: Optional[bool] = False,
-    full_refresh: Optional[bool] = False,
-    no_seed: Optional[bool] = False,
-    select: Optional[Tuple] = (),
-    models: Optional[Tuple] = (),
-    macros: Optional[Tuple] = (),
-) -> str:
-    command = []
-    if not no_seed:
-        command.append("dbt seed --full-refresh")
-
-    if macros:
-        command.append(f'dbt run-operation + {"&& dbt run-operation".join(macros)}')
-    else:
-        subcommand = f"dbt {cmd}"
-        if select and not no_seed:
-            subcommand += " --select " + " ".join(select)
-        if models:
-            subcommand += " --models " + " ".join(models)
-        if full_refresh:
-            subcommand += " --full-refresh"
-        if not no_fail_fast:
-            subcommand += " --fail-fast"
-        command.append(subcommand)
-
-    if not persist:
-        command.append("dbt run-operation drop_branch_schemas")
-
-    return ' && '.join(command)
-
 
 def dbt_env_vars(branch: str) -> Dict:
     return {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->
## Pull request checklist

Before submitting your PR, please review the following checklist:

- [x] Consider adding a unit test if your PR resolves an issue.
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Breaking changes

- [ ] Check if this pull request introduces a breaking change

## What does this implement/fix? Explain your changes.

- Remove the shell_options utility to simplify dbt run and test commands and decouple their logic. This was a relic from the very first iteration of palm and causes tight coupling between these 2 core palm-dbt commands
- Removes unnecessary complexity and allows us to more easily reason about what a given command will do
- Passing locals as kwargs was fragile and didn't work 100% of the time
- Add exclude option to run and test
- Remove macro option from `palm run` - this was not being used and caused complex branching logic. With the new `palm dbt` passthrough command, users are able to execute `dbt run-operation` directly which is way more likely than remembering how the `--macros` option works.

## Any other comments?
- this change paves the way for better 'sensible defaults' in the future

## Where has this been tested?

**Operating System:** macOD

**Platform:** dbt 1.2.x

**Target Platform:** dbt > 1.0 (should be backwards compatible)
