### PR TITLE
[FEATURE] No-op Command for downloading prod artifacts

### DIFF
--- a/palm/plugins/dbt/commands/cmd_prod-artifacts.py
+++ b/palm/plugins/dbt/commands/cmd_prod-artifacts.py
@@ -5,7 +5,7 @@ from palm.plugins.dbt.dbt_palm_utils import dbt_env_vars
 @click.command("prod-artifacts")
 @click.pass_context
 def cli(ctx):
-    """No-op command: Download your DBT artifacts from production.
+    """No-op command: Download your dbt artifacts from production.
 
     This command is a no-op as the implementation will differ depending on your
     production environment. You should override this command in your own

--- a/palm/plugins/dbt/commands/cmd_prod-artifacts.py
+++ b/palm/plugins/dbt/commands/cmd_prod-artifacts.py
@@ -1,0 +1,24 @@
+import click
+from palm.plugins.dbt.dbt_palm_utils import dbt_env_vars
+
+
+@click.command("prod-artifacts")
+@click.pass_context
+def cli(ctx):
+    """No-op command: Download your DBT artifacts from production.
+
+    This command is a no-op as the implementation will differ depending on your
+    production environment. You should override this command in your own
+    project by running `palm override --name prod-artifacts` and then
+    implementing the logic to download your DBT artifacts from production.
+    """
+
+    plugin_config = ctx.obj.plugin_config("dbt")
+    artifact_path = plugin_config.dbt_artifacts_prod
+
+    cmd = "echo 'No-op command! Please override this command in your own project by running: palm override --name prod-artifacts'"
+
+    env_vars = dbt_env_vars(ctx.obj.palm.branch)
+    success, msg = ctx.obj.run_in_docker(cmd, env_vars)
+
+    click.secho(msg, fg="green" if success else "red")

--- a/palm/plugins/dbt/commands/cmd_prod-artifacts.py
+++ b/palm/plugins/dbt/commands/cmd_prod-artifacts.py
@@ -16,9 +16,9 @@ def cli(ctx):
     plugin_config = ctx.obj.plugin_config("dbt")
     artifact_path = plugin_config.dbt_artifacts_prod
 
-    cmd = "echo 'No-op command! Please override this command in your own project by running: palm override --name prod-artifacts'"
+    msg = "No-op command! Please override this command in your own project by running: palm override --name prod-artifacts'"
 
     env_vars = dbt_env_vars(ctx.obj.palm.branch)
-    success, msg = ctx.obj.run_in_docker(cmd, env_vars)
+    # success, msg = ctx.obj.run_in_docker(cmd, env_vars)
 
-    click.secho(msg, fg="green" if success else "red")
+    click.secho(msg, fg="red")


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->
## Pull request checklist

Before submitting your PR, please review the following checklist:

- [x] Consider adding a unit test if your PR resolves an issue.
<!-- TODO: Implement palm test and palm lint for this plugin -->
<!-- - [ ] All new and existing tests pass locally (`palm test`) -->
<!-- - [ ] Lint (`palm lint`) has passed locally and any fixes were made for failures -->
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Breaking changes

- [ ] Check if this pull request introduces a breaking change

## What does this implement/fix? Explain your changes.

This is implemented as a no-op command as there are many places artifacts can be stored and many nuances to how they should be downloaded.

In the future, we may implement a mechanism to download from common storage locations (dbt cloud, GCS, S3) but we do not currently have bandwidth to do this and want to keep other valuable features moving.

## Does this close any currently open issues?
 Unblocks remaining work on #67 

## Where has this been tested?

**Operating System:** MacOs

**Platform:** python3.9