### PR TITLE
[BUGFIX] Appended `--full-refresh` flag twice

### DIFF
--- a/palm/plugins/dbt/commands/cmd_run.py
+++ b/palm/plugins/dbt/commands/cmd_run.py
@@ -127,8 +127,6 @@ def build_run_command(
         cmd.extend(exclude)
     if not no_fail_fast:
         cmd.append("--fail-fast")
-    if full_refresh:
-        cmd.append("--full-refresh")
     if defer:
         cmd.append("--defer")
     if vars:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->
## Pull request checklist

Before submitting your PR, please review the following checklist:

- [ ] Consider adding a unit test if your PR resolves an issue.
<!-- TODO: Implement palm test and palm lint for this plugin -->
<!-- - [ ] All new and existing tests pass locally (`palm test`) -->
<!-- - [ ] Lint (`palm lint`) has passed locally and any fixes were made for failures -->
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Breaking changes

- [ ] Check if this pull request introduces a breaking change

## What does this implement/fix? Explain your changes.
The `build_run_command` had been updated to add `--full-refresh` to both `dbt run` and `dbt seed` commands when the flag was used, but there was already a condition to add on the flag to the `dbt run` command, resulting in it being appended on twice. Functionally, it still worked, but it was a goofy mistake that doesn't need to be there!

## Does this close any currently open issues?
N/A

## Any other comments?
Nope

## Where has this been tested?

**Operating System:** Mac M1 Max, Ventura OS

**Platform:** …

**Target Platform:** …
