### PR TITLE
[BUGFIX] Remove stateful selectors from palm run

### DIFF
--- a/palm/plugins/dbt/commands/cmd_run.py
+++ b/palm/plugins/dbt/commands/cmd_run.py
@@ -107,18 +107,13 @@ def build_run_command(
     vars: Optional[str] = None,
 ) -> str:
     cmd = []
-    if full_refresh:
-        full_refresh_option = "--full-refresh"
-    else:
-        full_refresh_option = ""
+    full_refresh_option = " --full-refresh" if full_refresh else ""
 
     if not no_seed:
-        cmd.append(f"dbt seed {full_refresh_option}")
+        cmd.append(f"dbt seed{full_refresh_option}")
         cmd.append("&&")
 
-    cmd.append(f"dbt run {full_refresh_option}")
-    if not targets:
-        cmd.extend(["--defer", "--select", "state:new", "state:modified+"])
+    cmd.append(f"dbt run{full_refresh_option}")
     if targets:
         cmd.append("--select")
         cmd.extend(targets)
@@ -128,6 +123,7 @@ def build_run_command(
     if not no_fail_fast:
         cmd.append("--fail-fast")
     if defer:
+        cmd.extend(["--select", "state:new", "state:modified+"])
         cmd.append("--defer")
     if vars:
         cmd.append(f"--vars '{vars}'")

--- a/palm/plugins/dbt/commands/cmd_run.py
+++ b/palm/plugins/dbt/commands/cmd_run.py
@@ -118,7 +118,7 @@ def build_run_command(
 
     cmd.append(f"dbt run {full_refresh_option}")
     if not targets:
-        cmd.extend(["--select", "state:new", "state:modified+"])
+        cmd.extend(["--defer", "--select", "state:new", "state:modified+"])
     if targets:
         cmd.append("--select")
         cmd.extend(targets)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->
## Pull request checklist

Before submitting your PR, please review the following checklist:

- [x] Consider adding a unit test if your PR resolves an issue.
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Breaking changes

- [ ] Check if this pull request introduces a breaking change

## What does this implement/fix? Explain your changes.

`palm run` was applying stateful selectors, while dbt was not using a stateful run. This makes it difficult to run the entire project and introduces an unexpected state where no models are executed.


## Any other comments?

Also fixed up some whitespace in the command (--fail-fast changes)

## Where has this been tested?

**Operating System:** MacOS

**Platform:** Python3.9
