### PR TITLE
[FEATURE] Compatibility with pyyaml 6.0

### DIFF
--- a/palm/plugins/dbt/requirements.txt
+++ b/palm/plugins/dbt/requirements.txt
@@ -1,3 +1,3 @@
 palm >=2.5.1, <3.0
-pyyaml >= 5.0, < 5.5
+pyyaml >= 5.0
 sqlparse >= 0.3.1


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->
## Pull request checklist

Before submitting your PR, please review the following checklist:

- [x] Consider adding a unit test if your PR resolves an issue.
<!-- TODO: Implement palm test and palm lint for this plugin -->
<!-- - [ ] All new and existing tests pass locally (`palm test`) -->
<!-- - [ ] Lint (`palm lint`) has passed locally and any fixes were made for failures -->
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Breaking changes

- [ ] Check if this pull request introduces a breaking change

## What does this implement/fix? Explain your changes.

dbt-core now depends on pyyaml 6.0, we want to make sure folks can install palm-dbt in an environment where they are running dbt on the metal. The good news is we just have to remove the version pin. All our `yaml.load` calls specify the loader

## Does this close any currently open issues?
…

## Any other comments?
This change will need to be deployed along with a corresponding patch in palm cli (https://github.com/palmetto/palm-cli/pull/96)
