### PR TITLE
[FEATURE] Consistent dbt command options

### DIFF
--- a/palm/plugins/dbt/commands/cmd_compile.py
+++ b/palm/plugins/dbt/commands/cmd_compile.py
@@ -4,15 +4,29 @@ from palm.plugins.dbt.dbt_palm_utils import dbt_env_vars
 
 
 @click.command("compile")
-@click.option("--models", multiple=True, help="see dbt docs on models flag")
-@click.pass_context
-def cli(ctx, models: Optional[Tuple] = tuple()):
-    """Cleans up target directory and dependencies, then compiles dbt"""
+@click.option("--models", "-m", multiple=True, help="See dbt docs on models flag")
+@click.option("--select", "-s", multiple=True, help="See dbt docs on select flag")
+@click.option("--exclude", "-e", multiple=True, help="See dbt docs on exclude flag")
+@click.pass_obj
+def cli(
+    environment,
+    models: Optional[Tuple] = tuple(),
+    select: Optional[Tuple] = tuple(),
+    exclude: Optional[Tuple] = tuple(),
+):
+    """Compiles the dbt repo"""
+    env_vars = dbt_env_vars(environment.palm.branch)
 
-    cmd = "dbt compile"
-    if models:
-        cmd += f" --models {' '.join(models)}"
+    # --select and --models are interchangeable on dbt >= v1, combine the lists of selections
+    targets = list(set(models + select))
 
-    env_vars = dbt_env_vars(ctx.obj.palm.branch)
-    success, msg = ctx.obj.run_in_docker(cmd, env_vars)
+    cmd = ["dbt compile"]
+    if targets:
+        cmd.append("--select")
+        cmd.extend(targets)
+    if exclude:
+        cmd.append('--exclude')
+        cmd.extend(exclude)
+    
+    success, msg = environment.run_in_docker(" ".join(cmd), env_vars)
     click.secho(msg, fg="green" if success else "red")

--- a/palm/plugins/dbt/commands/cmd_compile.py
+++ b/palm/plugins/dbt/commands/cmd_compile.py
@@ -27,6 +27,6 @@ def cli(
     if exclude:
         cmd.append('--exclude')
         cmd.extend(exclude)
-    
+
     success, msg = environment.run_in_docker(" ".join(cmd), env_vars)
     click.secho(msg, fg="green" if success else "red")

--- a/palm/plugins/dbt/commands/cmd_cycle.py
+++ b/palm/plugins/dbt/commands/cmd_cycle.py
@@ -23,7 +23,7 @@ def cli(
     models: Optional[Tuple] = tuple(),
     select: Optional[Tuple] = tuple(),
 ):
-    """Consecutive run-test of the DBT repo. `count` is the number of run/test cycles to execute, defaults to 2"""
+    """Consecutive run-test of the dbt repo. `count` is the number of run/test cycles to execute, defaults to 2"""
 
     def add_models(command: str) -> str:
         if models:

--- a/palm/plugins/dbt/commands/cmd_model.py
+++ b/palm/plugins/dbt/commands/cmd_model.py
@@ -11,7 +11,7 @@ valid_model_types = ['tmp', 'staging', 'intermediate', 'dim', 'fact']
 
 @click.group()
 def cli():
-    """DBT model tools"""
+    """dbt model tools"""
     pass
 
 

--- a/palm/plugins/dbt/commands/cmd_prod-artifacts.py
+++ b/palm/plugins/dbt/commands/cmd_prod-artifacts.py
@@ -12,13 +12,13 @@ def cli(environment):
     This command is a no-op as the implementation will differ depending on your
     production environment. You should override this command in your own
     project by running `palm override --name prod-artifacts` and then
-    implementing the logic to download your DBT artifacts from production.
+    implementing the logic to download your dbt artifacts from production.
     """
 
     plugin_config = environment.plugin_config("dbt")
     artifact_path = plugin_config.dbt_artifacts_prod
 
-    msg = "No-op command! Please override this command in your own project by running: palm override --name prod-artifacts'"
+    msg = "No-op command! Please override this command in your own project by running: 'palm override --name prod-artifacts'"
 
     env_vars = dbt_env_vars(environment.palm.branch)
     # success, msg = environment.run_in_docker(cmd, env_vars)

--- a/palm/plugins/dbt/commands/cmd_run.py
+++ b/palm/plugins/dbt/commands/cmd_run.py
@@ -7,6 +7,7 @@ import sys
 @click.command("run")
 @click.option(
     "--no-fail-fast",
+    "-nx",
     is_flag=True,
     help="Turns off --fail-fast. See dbt docs on fail-fast flag.",
 )
@@ -14,10 +15,11 @@ import sys
 @click.option("--models", "-m", multiple=True, help="See dbt docs on models flag")
 @click.option("--select", "-s", multiple=True, help="See dbt docs on select flag")
 @click.option("--exclude", "-e", multiple=True, help="See dbt docs on exclude flag")
-@click.option("--defer", is_flag=True, help="See dbt docs on defer flag")
-@click.option("--iterative", is_flag=True, help="Iterative stateful dbt run")
+@click.option("--defer", "-d", is_flag=True, help="See dbt docs on defer flag")
+@click.option("--iterative", "-i", is_flag=True, help="Iterative stateful dbt run")
 @click.option(
     "--full-refresh",
+    "-f",
     is_flag=True,
     help="Will perform a full refresh on incremental models",
 )
@@ -36,7 +38,7 @@ def cli(
     exclude: Optional[Tuple] = tuple(),
     vars: Optional[str] = None,
 ):
-    """Runs the DBT repo."""
+    """Runs the dbt repo."""
     stateful = iterative or defer
 
     if defer:
@@ -92,7 +94,7 @@ def cli(
 
     if clean:
         success, msg = environment.run_in_docker(
-            "dbt run-operation drop_branch_schemas && dbt clean", env_vars
+            "dbt run-operation drop_branch_schemas", env_vars
         )
         click.secho(msg, fg="green" if success else "red")
 

--- a/palm/plugins/dbt/commands/cmd_snapshot.py
+++ b/palm/plugins/dbt/commands/cmd_snapshot.py
@@ -25,7 +25,7 @@ def cli(
         cmd.append('--exclude')
         cmd.extend(exclude)
 
-    success, msg = environment.run_in_docker(cmd, env_vars)
+    success, msg = environment.run_in_docker(" ".join(cmd), env_vars)
     click.secho(msg, fg="green" if success else "red")
 
     if clean:

--- a/palm/plugins/dbt/commands/cmd_snapshot.py
+++ b/palm/plugins/dbt/commands/cmd_snapshot.py
@@ -16,7 +16,7 @@ def cli(
 ):
     """Executes the dbt snapshots."""
     env_vars = dbt_env_vars(environment.palm.branch)
-    
+
     cmd = ["dbt snapshot"]
     if select:
         cmd.append("--select")

--- a/palm/plugins/dbt/commands/cmd_snapshot.py
+++ b/palm/plugins/dbt/commands/cmd_snapshot.py
@@ -12,7 +12,7 @@ def cli(
     environment,
     clean: bool,
     select: Optional[Tuple] = tuple(),
-    exclude: Optional[Tuple] = tuple()
+    exclude: Optional[Tuple] = tuple(),
 ):
     """Executes the dbt snapshots."""
     env_vars = dbt_env_vars(environment.palm.branch)

--- a/palm/plugins/dbt/commands/cmd_snapshot.py
+++ b/palm/plugins/dbt/commands/cmd_snapshot.py
@@ -5,17 +5,31 @@ from palm.plugins.dbt.dbt_palm_utils import dbt_env_vars
 
 @click.command("snapshot")
 @click.option("--clean", is_flag=True, help="Drop the test schema after the run")
-@click.option("--select", multiple=True)
-@click.pass_context
-def cli(ctx, clean: bool, select: Optional[Tuple] = tuple()):
-    """Executes the DBT snapshots."""
-
-    cmd = "dbt snapshot"
+@click.option("--select", "-s", multiple=True, help="See dbt docs on select flag")
+@click.option("--exclude", "-e", multiple=True, help="See dbt docs on exclude flag")
+@click.pass_obj
+def cli(
+    environment,
+    clean: bool,
+    select: Optional[Tuple] = tuple(),
+    exclude: Optional[Tuple] = tuple()
+):
+    """Executes the dbt snapshots."""
+    env_vars = dbt_env_vars(environment.palm.branch)
+    
+    cmd = ["dbt snapshot"]
     if select:
-        cmd += f" --select " + " ".join(select)
-    if clean:
-        cmd += " && dbt run-operation drop_branch_schemas"
+        cmd.append("--select")
+        cmd.extend(select)
+    if exclude:
+        cmd.append('--exclude')
+        cmd.extend(exclude)
 
-    env_vars = dbt_env_vars(ctx.obj.palm.branch)
-    success, msg = ctx.obj.run_in_docker(cmd, env_vars)
+    success, msg = environment.run_in_docker(cmd, env_vars)
     click.secho(msg, fg="green" if success else "red")
+
+    if clean:
+        success, msg = environment.run_in_docker(
+            "dbt run-operation drop_branch_schemas", env_vars
+        )
+        click.secho(msg, fg="green" if success else "red")

--- a/palm/plugins/dbt/commands/cmd_test.py
+++ b/palm/plugins/dbt/commands/cmd_test.py
@@ -47,7 +47,7 @@ def cli(
     # --select and --models are interchangeable on dbt >= v1, combine the lists of selections
     targets = list(set(models + select))
 
-    run_cmd = build_run_command(
+    run_cmd = build_test_command(
         no_fail_fast=no_fail_fast,
         targets=targets,
         exclude=exclude,

--- a/palm/plugins/dbt/commands/cmd_test.py
+++ b/palm/plugins/dbt/commands/cmd_test.py
@@ -12,7 +12,9 @@ import sys
 @click.option("--select", "-s", multiple=True, help="See dbt docs on select flag")
 @click.option("--exclude", "-e", multiple=True, help="See dbt docs on exclude flag")
 @click.option("--defer", "-d", is_flag=True, help="See dbt docs on defer flag")
-@click.option("--no-fail-fast", "-nx", is_flag=True, help="Runs all tests even if one fails")
+@click.option(
+    "--no-fail-fast", "-nx", is_flag=True, help="Runs all tests even if one fails"
+)
 @click.pass_obj
 def cli(
     environment,
@@ -82,8 +84,9 @@ def build_run_command(
         if not targets:
             cmd.extend(["--select", "state:new", "state:modified+"])
         cmd.append("--defer")
-    
+
     return " ".join(cmd)
+
 
 def set_env_vars(environment, defer: bool = False) -> dict:
     plugin_config = environment.plugin_config('dbt')

--- a/palm/plugins/dbt/commands/cmd_test.py
+++ b/palm/plugins/dbt/commands/cmd_test.py
@@ -63,7 +63,7 @@ def cli(
         click.secho(msg, fg="green" if success else "red")
 
 
-def build_run_command(
+def build_test_command(
     defer: bool = False,
     no_fail_fast: bool = False,
     targets: Optional[list] = None,

--- a/palm/plugins/dbt/commands/cmd_test.py
+++ b/palm/plugins/dbt/commands/cmd_test.py
@@ -1,42 +1,96 @@
 import click
 from typing import Optional, Tuple
 from palm.plugins.dbt.dbt_palm_utils import dbt_env_vars
+import sys
 
 
 @click.command('test')
 @click.option(
-    "--clean", is_flag=True, help="drop the test schema after the run is complete"
+    "--clean", is_flag=True, help="Drop the test schema after the run is complete"
 )
-@click.option("--models", multiple=True, help="see dbt docs on models flag")
-@click.option("--select", multiple=True, help="see dbt docs on select flag")
-@click.option("--exclude", multiple=True, help="see dbt docs on exclude flag")
-@click.option("--no-fail-fast", is_flag=True, help="will run all tests if one fails")
-@click.pass_context
+@click.option("--models", "-m", multiple=True, help="See dbt docs on models flag")
+@click.option("--select", "-s", multiple=True, help="See dbt docs on select flag")
+@click.option("--exclude", "-e", multiple=True, help="See dbt docs on exclude flag")
+@click.option("--defer", "-d", is_flag=True, help="See dbt docs on defer flag")
+@click.option("--no-fail-fast", "-nx", is_flag=True, help="Runs all tests even if one fails")
+@click.pass_obj
 def cli(
-    ctx,
+    environment,
     clean: bool,
     no_fail_fast: bool,
+    defer: bool,
     models: Optional[Tuple] = tuple(),
     select: Optional[Tuple] = tuple(),
     exclude: Optional[Tuple] = tuple(),
 ):
-    """Tests the DBT repo"""
+    """Tests the dbt repo"""
 
-    cmd = ['dbt', 'test']
-    if select:
+    if defer:
+        click.secho("Running 'palm prod-artifacts'...", fg='yellow')
+        exit_code, _, _ = environment.run_on_host("palm prod-artifacts")
+        if exit_code == 2:
+            click.secho(
+                "'palm prod-artifacts' not implemented. Can't use --defer without it!",
+                fg='red',
+            )
+            sys.exit(1)
+        elif exit_code != 0:
+            click.secho(
+                "Something went wrong while pulling the prod artifacts.", fg='red'
+            )
+            sys.exit(1)
+
+    env_vars = set_env_vars(environment, defer)
+
+    # --select and --models are interchangeable on dbt >= v1, combine the lists of selections
+    targets = list(set(models + select))
+
+    run_cmd = build_run_command(
+        no_fail_fast=no_fail_fast,
+        targets=targets,
+        exclude=exclude,
+        defer=defer,
+    )
+    success, msg = environment.run_in_docker(run_cmd, env_vars)
+    click.secho(msg, fg="green" if success else "red")
+
+    if clean:
+        success, msg = environment.run_in_docker(
+            "dbt run-operation drop_branch_schemas", env_vars
+        )
+        click.secho(msg, fg="green" if success else "red")
+
+
+def build_run_command(
+    defer: bool = False,
+    no_fail_fast: bool = False,
+    targets: Optional[list] = None,
+    exclude: Optional[Tuple] = None,
+) -> str:
+    cmd = []
+
+    cmd.append(f"dbt test")
+    if targets:
         cmd.append('--select')
-        cmd.extend(select)
-    if models:
-        cmd.append('--models')
-        cmd.extend(models)
+        cmd.extend(targets)
     if exclude:
         cmd.append('--exclude')
         cmd.extend(exclude)
     if not no_fail_fast:
         cmd.append('--fail-fast')
-    if clean:
-        cmd.append('&& dbt run-operation drop_branch_schemas')
+    if defer:
+        if not targets:
+            cmd.extend(["--select", "state:new", "state:modified+"])
+        cmd.append("--defer")
+    
+    return " ".join(cmd)
 
-    env_vars = dbt_env_vars(ctx.obj.palm.branch)
-    success, msg = ctx.obj.run_in_docker(" ".join(cmd), env_vars)
-    click.secho(msg, fg="green" if success else "red")
+def set_env_vars(environment, defer: bool = False) -> dict:
+    plugin_config = environment.plugin_config('dbt')
+    env_vars = dbt_env_vars(environment.palm.branch)
+    if defer:
+        env_vars['DBT_DEFER_TO_STATE'] = 'true'
+        env_vars['DBT_ARTIFACT_STATE_PATH'] = plugin_config.dbt_artifacts_prod
+    else:
+        env_vars['DBT_ARTIFACT_STATE_PATH'] = plugin_config.dbt_artifacts_local
+    return env_vars

--- a/palm/plugins/dbt/dbt_palm_utils.py
+++ b/palm/plugins/dbt/dbt_palm_utils.py
@@ -2,7 +2,7 @@ import re
 from typing import Dict
 from palm.plugins.dbt.local_user_lookup import local_user_lookup
 
-""" Shared DBT utilities to build out common CLI options """
+""" Shared dbt utilities to build out common CLI options """
 
 
 def dbt_env_vars(branch: str) -> Dict:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->
## Pull request checklist

Before submitting your PR, please review the following checklist:

- [ ] Consider adding a unit test if your PR resolves an issue.
<!-- TODO: Implement palm test and palm lint for this plugin -->
<!-- - [ ] All new and existing tests pass locally (`palm test`) -->
<!-- - [ ] Lint (`palm lint`) has passed locally and any fixes were made for failures -->
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Breaking changes

- [ ] Check if this pull request introduces a breaking change

## What does this implement/fix? Explain your changes.
As we have developed `palm run` to be more refined, our other commands have fallen behind.

This PR updates `snapshot` , `test`, and `compile` to use the same selection flags, the `--defer` logic (where it can be used), and the other improvements that `palm run` enjoys like the newer method of building the commands, the new method of cleaning up after the run, and the flag shortcuts (eg. "-s"). This PR also fixes some comments to consistently lower-case dbt, converts these commands to also all use `@click.pass_obj` rather than `@click.pass_environment`, and makes sure all the commands with the `--clean` flag clean up in the same manner.

## Does this close any currently open issues?
No

## Any other comments?
I tried to lint the codebase but couldn't--it said no config found

## Where has this been tested?

**Operating System:** Mac OS M2

**Platform:** What does this even mean

**Target Platform:** Also what does this even mean
