### PR TITLE
Feature: seeds are opt in

### DIFF
--- a/palm/plugins/dbt/commands/cmd_cycle.py
+++ b/palm/plugins/dbt/commands/cmd_cycle.py
@@ -13,13 +13,13 @@ from palm.plugins.dbt.dbt_palm_utils import dbt_env_vars
 )
 @click.option("--models", multiple=True, help="see dbt docs on models flag")
 @click.option("--select", multiple=True, help="see dbt docs on select flag")
-@click.option("--no-seed", is_flag=True, help="will skip seed full refresh")
+@click.option("--seed", is_flag=True, help="will skip seed full refresh")
 @click.pass_context
 def cli(
     ctx,
     count: int,
     persist: bool,
-    no_seed: bool,
+    seed: bool,
     models: Optional[Tuple] = tuple(),
     select: Optional[Tuple] = tuple(),
 ):
@@ -46,7 +46,7 @@ def cli(
 
     def make_cmd():
         commands = []
-        if not no_seed:
+        if seed:
             seed_cmd = "dbt seed --full-refresh"
             commands.append(add_select(seed_cmd))
 

--- a/palm/plugins/dbt/commands/cmd_run.py
+++ b/palm/plugins/dbt/commands/cmd_run.py
@@ -21,7 +21,7 @@ import sys
     is_flag=True,
     help="Will perform a full refresh on incremental models",
 )
-@click.option("--no-seed", is_flag=True, help="Will skip seed full refresh")
+@click.option("--seed", is_flag=True, help="Run dbt seed before dbt run")
 @click.pass_obj
 def cli(
     environment,
@@ -30,7 +30,7 @@ def cli(
     full_refresh: bool,
     iterative: bool,
     defer: bool,
-    no_seed: bool,
+    seed: bool,
     models: Optional[Tuple] = tuple(),
     select: Optional[Tuple] = tuple(),
     exclude: Optional[Tuple] = tuple(),
@@ -62,7 +62,7 @@ def cli(
     run_cmd = build_run_command(
         # Is there a better way to pass these args in?
         full_refresh=full_refresh,
-        no_seed=(no_seed or defer),
+        seed=seed,
         no_fail_fast=(no_fail_fast or iterative),
         targets=targets,
         exclude=exclude,
@@ -83,7 +83,7 @@ def cli(
             env_vars = set_env_vars(environment, stateful)
             stateful_run_cmd = build_run_command(
                 targets=["result:error", "result:skipped"],
-                no_seed=iterative,
+                seed=False,
                 no_fail_fast=iterative,
             )
             success, msg = environment.run_in_docker(stateful_run_cmd, env_vars)
@@ -99,7 +99,7 @@ def cli(
 
 def build_run_command(
     full_refresh: bool = False,
-    no_seed: bool = True,
+    seed: bool = True,
     no_fail_fast: bool = False,
     targets: Optional[list] = None,
     exclude: Optional[Tuple] = None,
@@ -109,8 +109,8 @@ def build_run_command(
     cmd = []
     full_refresh_option = " --full-refresh" if full_refresh else ""
 
-    if not no_seed:
-        cmd.append(f"dbt seed{full_refresh_option}")
+    if seed:
+        cmd.append(f"dbt seed --full-refresh")
         cmd.append("&&")
 
     cmd.append(f"dbt run{full_refresh_option}")

--- a/palm/plugins/dbt/commands/cmd_seed.py
+++ b/palm/plugins/dbt/commands/cmd_seed.py
@@ -9,7 +9,12 @@ from palm.plugins.dbt.dbt_palm_utils import dbt_env_vars
 )
 @click.option("--select", multiple=True, help="see dbt docs on select flag")
 @click.option("--exclude", multiple=True, help="see dbt docs on exclude flag")
-@click.option("--no-full-refresh", "-nf", is_flag=True, help="Insert seeds instead of recreating the table")
+@click.option(
+    "--no-full-refresh",
+    "-nf",
+    is_flag=True,
+    help="Insert seeds instead of recreating the table",
+)
 @click.pass_context
 def cli(
     ctx,

--- a/palm/plugins/dbt/commands/cmd_seed.py
+++ b/palm/plugins/dbt/commands/cmd_seed.py
@@ -7,17 +7,17 @@ from palm.plugins.dbt.dbt_palm_utils import dbt_env_vars
 @click.option(
     "--clean", is_flag=True, help="drop the test schema after the run is complete"
 )
-@click.option("--select", multiple=True, help="see dbt docs on select flag")
-@click.option("--exclude", multiple=True, help="see dbt docs on exclude flag")
+@click.option("--select", '-s', multiple=True, help="see dbt docs on select flag")
+@click.option("--exclude", '-e', multiple=True, help="see dbt docs on exclude flag")
 @click.option(
     "--no-full-refresh",
     "-nf",
     is_flag=True,
     help="Insert seeds instead of recreating the table",
 )
-@click.pass_context
+@click.obj
 def cli(
-    ctx,
+    environment,
     clean: bool,
     no_full_refresh: bool,
     select: Optional[Tuple] = tuple(),
@@ -37,6 +37,6 @@ def cli(
     if clean:
         cmd.append('&& dbt run-operation drop_branch_schemas')
 
-    env_vars = dbt_env_vars(ctx.obj.palm.branch)
-    success, msg = ctx.obj.run_in_docker(" ".join(cmd), env_vars)
+    env_vars = dbt_env_vars(environment.palm.branch)
+    success, msg = environment.run_in_docker(" ".join(cmd), env_vars)
     click.secho(msg, fg="green" if success else "red")

--- a/palm/plugins/dbt/commands/cmd_seed.py
+++ b/palm/plugins/dbt/commands/cmd_seed.py
@@ -1,0 +1,37 @@
+import click
+from typing import Optional, Tuple
+from palm.plugins.dbt.dbt_palm_utils import dbt_env_vars
+
+
+@click.command('seed')
+@click.option(
+    "--clean", is_flag=True, help="drop the test schema after the run is complete"
+)
+@click.option("--select", multiple=True, help="see dbt docs on select flag")
+@click.option("--exclude", multiple=True, help="see dbt docs on exclude flag")
+@click.option("--no-full-refresh", "-nf", is_flag=True, help="Insert seeds instead of recreating the table")
+@click.pass_context
+def cli(
+    ctx,
+    clean: bool,
+    no_full_refresh: bool,
+    select: Optional[Tuple] = tuple(),
+    exclude: Optional[Tuple] = tuple(),
+):
+    """Run dbt seeds"""
+
+    cmd = ['dbt', 'seed']
+    if select:
+        cmd.append('--select')
+        cmd.extend(select)
+    if exclude:
+        cmd.append('--exclude')
+        cmd.extend(exclude)
+    if not no_full_refresh:
+        cmd.append('--full-refresh')
+    if clean:
+        cmd.append('&& dbt run-operation drop_branch_schemas')
+
+    env_vars = dbt_env_vars(ctx.obj.palm.branch)
+    success, msg = ctx.obj.run_in_docker(" ".join(cmd), env_vars)
+    click.secho(msg, fg="green" if success else "red")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->
## Pull request checklist

Before submitting your PR, please review the following checklist:

- [x] Consider adding a unit test if your PR resolves an issue.
<!-- TODO: Implement palm test and palm lint for this plugin -->
<!-- - [ ] All new and existing tests pass locally (`palm test`) -->
<!-- - [ ] Lint (`palm lint`) has passed locally and any fixes were made for failures -->
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Breaking changes

- [ ] Check if this pull request introduces a breaking change

## What does this implement/fix? Explain your changes.

Changes `palm run` and `palm cycle` to make seeds opt-in, rather than opt-out. This is preferable most of the time when working on regular models, which is the case for most dbt development tasks.

Defaults to `full-refresh` for seeds. This instructs dbt to recreate the seed table on each run, rather than inserting - this is necessary when making changes to seeds that have already been run on the current branch.

Adds a `palm seed` command to explicitly run seeds. This should be helpful when working on a seed, since we can `--select my_new_seed` for speed and efficiency.

## Does this close any currently open issues?

DP-389 (Palmetto internal)
